### PR TITLE
修复日期丢失，比如2017-07-23至2017-07-29整个礼拜日期丢失

### DIFF
--- a/src/calendar.vue
+++ b/src/calendar.vue
@@ -287,7 +287,7 @@ export default {
                     }
                 }
                 // 最后一行
-                if (day == 6 && line<4) {
+                if (day == 6 && i<lastDateOfMonth) {
                     line++
                 }else if (i == lastDateOfMonth) {
                     // line++


### PR DESCRIPTION
如果当前月份日期显示超过6行显示时，就会出现这个问题。